### PR TITLE
Rename Coord::contain method to contains

### DIFF
--- a/src/yosupo/container/segtree2d.hpp
+++ b/src/yosupo/container/segtree2d.hpp
@@ -22,7 +22,7 @@ template <monoid M> struct SegTree2D {
     }
 
     void add(Coord p, S x) {
-        assert(size.contain(p));
+        assert(size.contains(p));
 
         int r = p.r();
         r += size2;
@@ -33,7 +33,7 @@ template <monoid M> struct SegTree2D {
     }
 
     S get(Coord p) {
-        assert(size.contain(p));
+        assert(size.contains(p));
         return manager.get(d[p.r() + size2], p.c());
     }
 

--- a/src/yosupo/coord.hpp
+++ b/src/yosupo/coord.hpp
@@ -87,7 +87,7 @@ struct Coord {
                });
     }
 
-    bool contain(const Coord& t) const {
+    bool contains(const Coord& t) const {
         return 0 <= t.r() && t.r() < r() && 0 <= t.c() && t.c() < c();
     }
 

--- a/test/unittest/coord_test.cpp
+++ b/test/unittest/coord_test.cpp
@@ -128,15 +128,15 @@ TEST(CoordTest, Move8Iter) {
 TEST(CoordTest, Contain) {
     Coord size(5, 7);
 
-    EXPECT_TRUE(size.contain(Coord(0, 0)));
-    EXPECT_TRUE(size.contain(Coord(4, 6)));
-    EXPECT_TRUE(size.contain(Coord(2, 3)));
+    EXPECT_TRUE(size.contains(Coord(0, 0)));
+    EXPECT_TRUE(size.contains(Coord(4, 6)));
+    EXPECT_TRUE(size.contains(Coord(2, 3)));
 
-    EXPECT_FALSE(size.contain(Coord(-1, 0)));
-    EXPECT_FALSE(size.contain(Coord(0, -1)));
-    EXPECT_FALSE(size.contain(Coord(5, 0)));
-    EXPECT_FALSE(size.contain(Coord(0, 7)));
-    EXPECT_FALSE(size.contain(Coord(5, 7)));
+    EXPECT_FALSE(size.contains(Coord(-1, 0)));
+    EXPECT_FALSE(size.contains(Coord(0, -1)));
+    EXPECT_FALSE(size.contains(Coord(5, 0)));
+    EXPECT_FALSE(size.contains(Coord(0, 7)));
+    EXPECT_FALSE(size.contains(Coord(5, 7)));
 }
 
 TEST(CoordTest, Cells) {

--- a/test/unittest/coord_test.cpp
+++ b/test/unittest/coord_test.cpp
@@ -125,7 +125,7 @@ TEST(CoordTest, Move8Iter) {
                      Coord(5, 4), Coord(4, 4), Coord(4, 5), Coord(4, 6)}));
 }
 
-TEST(CoordTest, Contain) {
+TEST(CoordTest, Contains) {
     Coord size(5, 7);
 
     EXPECT_TRUE(size.contains(Coord(0, 0)));


### PR DESCRIPTION
- Rename contain method to contains in Coord class for better naming consistency
- Update all usages in segtree2d.hpp and coord_test.cpp
- All unit tests pass after changes

🤖 Generated with [Claude Code](https://claude.ai/code)