### PR TITLE
[codex] Add FastSet iterator

### DIFF
--- a/src/yosupo/container/fastset.hpp
+++ b/src/yosupo/container/fastset.hpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <utility>
 #include <vector>
 
@@ -123,6 +124,57 @@ struct FastSet {
         if (i <= 0) return -1;
         return or_less(i - 1);
     }
+
+    struct iterator {
+        using difference_type = std::ptrdiff_t;
+        using value_type = int;
+        using reference = int;
+        using pointer = void;
+        using iterator_category = std::bidirectional_iterator_tag;
+        using iterator_concept = std::bidirectional_iterator_tag;
+
+        iterator() : _f(nullptr), _i(0) {}
+        int operator*() const { return _i; }
+        iterator& operator++() {
+            _i = _f->more(_i);
+            return *this;
+        }
+        iterator operator++(int) {
+            iterator old = *this;
+            ++*this;
+            return old;
+        }
+        iterator& operator--() {
+            if (_i == _f->_n) {
+                _i = _f->or_less(_f->_n - 1);
+            } else {
+                _i = _f->less(_i);
+            }
+            return *this;
+        }
+        iterator operator--(int) {
+            iterator old = *this;
+            --*this;
+            return old;
+        }
+        bool operator==(const iterator& other) const {
+            return _f == other._f && _i == other._i;
+        }
+        bool operator!=(const iterator& other) const {
+            return !(*this == other);
+        }
+
+      private:
+        friend struct FastSet;
+        iterator(const FastSet* f, int i) : _f(f), _i(i) {}
+
+        const FastSet* _f;
+        int _i;
+    };
+
+    // a[i] = true である i を小さい順に走査する
+    iterator begin() const { return iterator(this, or_more(0)); }
+    iterator end() const { return iterator(this, _n); }
 
   private:
     int _n, _log;

--- a/test/unittest/container/fastset_test.cpp
+++ b/test/unittest/container/fastset_test.cpp
@@ -1,8 +1,11 @@
 #include "yosupo/container/fastset.hpp"
 
+#include <algorithm>
 #include <iterator>
 #include <limits>
+#include <ranges>
 #include <set>
+#include <vector>
 
 #include "gtest/gtest.h"
 #include "yosupo/random.hpp"
@@ -30,6 +33,27 @@ TEST(FastSetTest, Constructor) {
 }
 
 TEST(FastSetTest, Zero) { FastSet f(0); }
+
+TEST(FastSetTest, Iterator) {
+    bool a[] = {true, false, true, true, false, false, true};
+    FastSet f(7, [&](int i) { return a[i]; });
+
+    std::vector<int> v;
+    for (auto i : f) v.push_back(i);
+    ASSERT_EQ((std::vector<int>{0, 2, 3, 6}), v);
+
+    v.clear();
+    for (auto i : f | std::views::reverse) v.push_back(i);
+    ASSERT_EQ((std::vector<int>{6, 3, 2, 0}), v);
+
+    v.clear();
+    FastSet empty(0);
+    for (auto i : empty) v.push_back(i);
+    ASSERT_TRUE(v.empty());
+
+    for (auto i : empty | std::views::reverse) v.push_back(i);
+    ASSERT_TRUE(v.empty());
+}
 
 TEST(FastSetTest, Stress) {
     for (int n = 1; n <= 200; n++) {
@@ -61,6 +85,19 @@ TEST(FastSetTest, Stress) {
                 ASSERT_EQ(less, f.less(p));
             }
         }
+
+        std::vector<int> actual;
+        for (auto i : f) actual.push_back(i);
+        std::vector<int> expected;
+        for (int i : st) {
+            if (0 <= i && i < n) expected.push_back(i);
+        }
+        ASSERT_EQ(expected, actual);
+
+        actual.clear();
+        for (auto i : f | std::views::reverse) actual.push_back(i);
+        std::reverse(expected.begin(), expected.end());
+        ASSERT_EQ(expected, actual);
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `FastSet::iterator` plus `begin()` / `end()` so set bits can be scanned with range-based for, e.g. `for (auto i : f)`.
- Make the iterator bidirectional so `f | std::views::reverse` also works.
- Iterate set bit indices in ascending order by default, and cover forward/reverse iteration in unit tests.

Closes #188.

## Validation
- `git diff --check`
- Focused `fastset_test` with sanitizers passed locally.

Note: full `./test/run_unittest.sh` is blocked in this environment because `convolution_test.cpp` cannot find `<immintrin.h>`.